### PR TITLE
Added dataType text to method $.get in help-tooltip.js file

### DIFF
--- a/libraries/help-tooltip.js
+++ b/libraries/help-tooltip.js
@@ -3,7 +3,7 @@
   $.get('sketch.js', function(data) {
     var helpText = getCommentBlock(data);
     if (helpText) createHelp(helpText);
-  });
+  }, 'text');
 
   function getCommentBlock(data) {
     // RegEx from https://github.com/yavorskiy/comment-parser/blob/master/parser.js


### PR DESCRIPTION
Added `dataType=text` to method **$.get** in `help-tooltip.js` file to fix that generate new P5 instance then load `sketch.js`